### PR TITLE
Fix #36 Look for the first non FK column to generate random value

### DIFF
--- a/src/Generator/TableGenerator.cs
+++ b/src/Generator/TableGenerator.cs
@@ -57,15 +57,15 @@ namespace StrangerData.Generator
 
             if (!HasIdentityColumn())
             {
-                var firstColumn = _tableColumnInfoList.First();
+                var firstNonFKColumn = _tableColumnInfoList.First(c => c.IsForeignKey == false);
 
-                object identityValue = RandomValues.ForColumn(firstColumn);
+                object identityValue = RandomValues.ForColumn(firstNonFKColumn);
 
-                generatedValues[firstColumn.Name] = identityValue;
+                generatedValues[firstNonFKColumn.Name] = identityValue;
 
-                if (_dbDialect.RecordExists(_tableName, firstColumn.Name, identityValue))
+                if (_dbDialect.RecordExists(_tableName, firstNonFKColumn.Name, identityValue))
                 {
-                    return _dbDialect.GetValuesFromDatabase(_tableName, firstColumn.Name, identityValue);
+                    return _dbDialect.GetValuesFromDatabase(_tableName, firstNonFKColumn.Name, identityValue);
                 }
             }
 


### PR DESCRIPTION
When generating values for a table, look for the first column that is not a Foreign Key to generate a random value