### PR TITLE
Fix issue #38

### DIFF
--- a/src/Generator/TableGenerator.cs
+++ b/src/Generator/TableGenerator.cs
@@ -131,6 +131,18 @@ namespace StrangerData.Generator
                             }
                         }
                     } // if (column.IsForeignKey)
+                    else if (column.IsUnique)
+                    {
+                        object random = RandomValues.ForColumn(column);
+
+                        // Keep generating random value while they are not unique
+                        while (_dbDialect.RecordExists(_tableName, column.Name, random))
+                        {
+                            random = RandomValues.ForColumn(column);
+                        }
+
+                        generatedValuesDict[column.Name] = random;
+                    }
                     else
                     {
                         // Is not a foreign key

--- a/src/TableColumnInfo.cs
+++ b/src/TableColumnInfo.cs
@@ -54,5 +54,10 @@ namespace StrangerData
         /// Related key column, if the column is a foreign key.
         /// </summary>
         public string ForeignKeyColumn { get; set; }
+
+        /// <summary>
+        /// Indicates if the column has a unique constraint. Either Primary Key or Unique Constraint applies.
+        /// </summary>
+        public bool IsUnique { get; set; }
     }
 }

--- a/src/Utils/RandomValueGenerator.cs
+++ b/src/Utils/RandomValueGenerator.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StrangerData.Utils
 {
@@ -17,12 +13,12 @@ namespace StrangerData.Utils
                     return Any.String(columnInfo.MaxLength);
                 case ColumnType.Int:
                     // generates a random integer
-                    long maxValue = 10 ^ columnInfo.Precision - 1;
+                    long maxValue = (int)Math.Pow(10, columnInfo.Precision - 1);
                     if (maxValue > int.MaxValue)
                     {
-                        return Any.Long(1, columnInfo.Precision - 1);
+                        return Any.Long(1, maxValue);
                     }
-                    return Any.Int(1, 10 ^ columnInfo.Precision - 1);
+                    return Any.Int(1, (int)maxValue);
                 case ColumnType.Decimal:
                     // generates a random decimal
                     return Any.Double(columnInfo.Precision, columnInfo.Scale);
@@ -31,7 +27,7 @@ namespace StrangerData.Utils
                     return Any.Double(columnInfo.Precision, columnInfo.Scale);
                 case ColumnType.Long:
                     // generates a random long
-                    return Any.Long(1, 10 ^ columnInfo.Precision - 1);
+                    return Any.Long(1, (int)Math.Pow(10, columnInfo.Precision - 1));
                 case ColumnType.Boolean:
                     // generates a random boolean
                     return Any.Boolean();


### PR DESCRIPTION
Fix #38 - Handle unique columns properly
- Add IsUnique to column information
- When a column has an unique constraint, StrangerData will try to generate a random unique value for it. If the value generated already exists a new random value is generated.
 - Add unit test to check if RecordExists is called when column is unique

Fix evaluation of max values for random int and long
- Use Math.Pow instead of logical XOR to evaluate max values