### PR TITLE
Fix bug introduced in the fix of #38

### DIFF
--- a/src/Generator/TableGenerator.cs
+++ b/src/Generator/TableGenerator.cs
@@ -131,26 +131,20 @@ namespace StrangerData.Generator
                             }
                         }
                     } // if (column.IsForeignKey)
-                    else if (column.IsUnique)
+                    else if (column.IsIdentity == false)
                     {
                         object random = RandomValues.ForColumn(column);
 
-                        // Keep generating random value while they are not unique
-                        while (_dbDialect.RecordExists(_tableName, column.Name, random))
+                        if (column.IsUnique)
                         {
-                            random = RandomValues.ForColumn(column);
+                            // Keep generating random value while they are not unique
+                            while (_dbDialect.RecordExists(_tableName, column.Name, random))
+                            {
+                                random = RandomValues.ForColumn(column);
+                            }
                         }
 
                         generatedValuesDict[column.Name] = random;
-                    }
-                    else
-                    {
-                        // Is not a foreign key
-                        if (!column.IsIdentity)
-                        {
-                            // Nor a identity column
-                            generatedValuesDict[column.Name] = RandomValues.ForColumn(column);
-                        }
                     }
                 }
             }

--- a/src/StrangerData.SqlServer/SqlServerDialect.cs
+++ b/src/StrangerData.SqlServer/SqlServerDialect.cs
@@ -74,7 +74,7 @@ namespace StrangerData.SqlServer
 				SELECT CAST(
 					CASE WHEN EXISTS (
 						SELECT * from sys.key_constraints C
-						WHERE PARENT_OBJECT_ID in (OBJECT_ID('Mcc'))
+						WHERE PARENT_OBJECT_ID in (OBJECT_ID(@tableName))
 						AND unique_index_id = OUTCOLUMNS.column_id) THEN 1
 					ELSE 0
 					END


### PR DESCRIPTION
Fix Identity column value generation
- Before checking whether the column is unique and generating a random value for it, we must ensure the column is not Identity. This fixes this logic.

Remove hard-coded table name