### PR TITLE
Fix configuration access

### DIFF
--- a/src/StrangerData.SqlServer/project.json
+++ b/src/StrangerData.SqlServer/project.json
@@ -17,17 +17,25 @@
   },
 
   "dependencies": {
-    "StrangerData": "99.99.99",
-    "System.Data.SqlClient": "4.1.0",
-    "System.Linq": "4.3.0"
+    "StrangerData": "99.99.99"
   },
 
   "frameworks": {
     "dnxcore50": {
+      "dependencies": {
+        "System.Data.SqlClient": "4.1.0"
+      }
     },
     "net452": {
+      "dependencies": {
+        "System.Data.SqlClient": "4.3.0"
+      }
     },
     "netcoreapp1.0": {
+      "dependencies": {
+        "System.Data.SqlClient": "4.1.0",
+        "System.Linq": "4.3.0"
+      }
     }
   }
 }

--- a/src/StrangerData/DataFactory.cs
+++ b/src/StrangerData/DataFactory.cs
@@ -15,7 +15,7 @@ namespace StrangerData
         {
             _tearDownStack = new Stack<Action>();
 
-            string connectionString = ConfigurationManager.GetConnectionString(nameOrConnectionString) ?? nameOrConnectionString;
+            string connectionString = ConfigurationProvider.GetConnectionString(nameOrConnectionString) ?? nameOrConnectionString;
 
             _databaseDialect = DbDialectResolver.Resolve<TDialect>(connectionString);
         }

--- a/src/StrangerData/DataFactory.cs
+++ b/src/StrangerData/DataFactory.cs
@@ -15,9 +15,7 @@ namespace StrangerData
         {
             _tearDownStack = new Stack<Action>();
 
-            string connectionString = (ConfigurationManager.GetConnectionString(nameOrConnectionString) != null) ?
-                                            ConfigurationManager.GetConnectionString(nameOrConnectionString) :
-                                            nameOrConnectionString;
+            string connectionString = ConfigurationManager.GetConnectionString(nameOrConnectionString) ?? nameOrConnectionString;
 
             _databaseDialect = DbDialectResolver.Resolve<TDialect>(connectionString);
         }

--- a/src/StrangerData/Utils/ConfigurationProvider.cs
+++ b/src/StrangerData/Utils/ConfigurationProvider.cs
@@ -1,10 +1,20 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿#if NET452
+using System.Configuration;
+#else
+using Microsoft.Extensions.Configuration;
 using System.IO;
+#endif
 
 namespace StrangerData.Utils
 {
-    public class ConfigurationManager
+    public class ConfigurationProvider
     {
+#if NET452
+        public static string GetConnectionString(string name)
+        {
+            return ConfigurationManager.ConnectionStrings[name]?.ConnectionString;
+        }
+#else
         private static IConfigurationRoot _configuration;
 
         private static IConfigurationRoot LoadConfiguration()
@@ -25,5 +35,6 @@ namespace StrangerData.Utils
 
             return _configuration.GetConnectionString(name);
         }
+#endif
     }
 }

--- a/src/StrangerData/project.json
+++ b/src/StrangerData/project.json
@@ -16,18 +16,25 @@
     "tags": [ "fixture", "data-builder", "fake-data", "test-data", "integration-test" ]
   },
 
-  "dependencies": {
-    "Microsoft.Extensions.Configuration": "1.1.0",
-    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0"
-  },
-
   "frameworks": {
     "dnxcore50": {
+      "dependencies": {
+        "Microsoft.Extensions.Configuration": "1.1.0",
+        "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
+        "Microsoft.Extensions.Configuration.Json": "1.0.0"
+      }
     },
     "net452": {
+      "frameworkAssemblies": {
+        "System.Configuration": "4.0.0.0"
+      }
     },
     "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.Extensions.Configuration": "1.1.0",
+        "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
+        "Microsoft.Extensions.Configuration.Json": "1.0.0"
+      }
     }
   }
 }

--- a/test/StrangerData.UnitTests/project.json
+++ b/test/StrangerData.UnitTests/project.json
@@ -5,6 +5,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-build10025",
     "FluentAssertions": "4.19.0",
     "Moq": "4.5.30",
+    "Newtonsoft.Json": "9.0.1",
     "StrangerData": "99.99.99",
     "xunit": "2.1.0"
   },


### PR DESCRIPTION
The way the library was accessing the configuration did no longer support .NET 4.5.2 applications, since it was expecting the configuration to be on a dotnet core JSON config file. This pull request fixes that.