### PR TITLE
Add error handling generating random values to inform column name and type

### DIFF
--- a/src/StrangerData/Utils/RandomValueGenerator.cs
+++ b/src/StrangerData/Utils/RandomValueGenerator.cs
@@ -6,6 +6,18 @@ namespace StrangerData.Utils
     {
         public static object ForColumn(TableColumnInfo columnInfo)
         {
+            try
+            {
+                return GenerateForColumn(columnInfo);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Could not generate value for column Name=[{columnInfo.Name}] Type=[{columnInfo.ColumnType}]", ex);
+            }
+        }
+
+        private static object GenerateForColumn(TableColumnInfo columnInfo)
+        {
             switch (columnInfo.ColumnType)
             {
                 case ColumnType.String:


### PR DESCRIPTION
Adds a simple error handling code to inform the column name and type when an exception is thrown while generating a random value for a column.